### PR TITLE
Add option for merging virtual fields

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -12,6 +12,12 @@ module.exports = function(schema, options) {
           if (value !== undefined) self.set(path, value);
       }
     });
+    if (opts.virtuals) {
+      Object.keys(self.schema.virtuals).forEach(function (path) {
+        var value = getValue(obj, path);
+        if (value !== undefined) self.set(path, value);
+      });
+    }
     return this;
   });
 };


### PR DESCRIPTION
Enable merging virtual fields by setting `virtuals` option to `true`.

eg.

```
doc.merge(other, { virtuals: true })
```
